### PR TITLE
Test scripts for CSP grep plugin.

### DIFF
--- a/webroot/moth/w3af/grep/csp/csp_with_error_1.php
+++ b/webroot/moth/w3af/grep/csp/csp_with_error_1.php
@@ -1,0 +1,10 @@
+<?php
+/* Script send CSP headers with explicit error */
+$csp_headers = "default-src * ; script-src * ; object-src *";
+
+header("Content-Security-Policy: $csp_headers");
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<body>See HTTP header "Content-Security-Policy" values.</body>
+</html>

--- a/webroot/moth/w3af/grep/csp/csp_with_error_2.php
+++ b/webroot/moth/w3af/grep/csp/csp_with_error_2.php
@@ -1,0 +1,10 @@
+<?php
+/* Script send CSP headers with explicit error */
+$csp_headers = "default-src *";
+
+header("Content-Security-Policy: $csp_headers");
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<body>See HTTP header "Content-Security-Policy" values.</body>
+</html>

--- a/webroot/moth/w3af/grep/csp/csp_with_error_3.php
+++ b/webroot/moth/w3af/grep/csp/csp_with_error_3.php
@@ -1,0 +1,10 @@
+<?php
+/* Script send CSP headers with explicit error (here is the directive name that is invalid) */
+$csp_headers = "def-src * ; sript-src toto.com ; default-src *";
+
+header("Content-Security-Policy: $csp_headers");
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<body>See HTTP header "Content-Security-Policy" values.</body>
+</html>

--- a/webroot/moth/w3af/grep/csp/csp_without_error.php
+++ b/webroot/moth/w3af/grep/csp/csp_without_error.php
@@ -1,0 +1,10 @@
+<?php
+/* Script send CSP headers without error */
+$csp_headers = "default-src 'self' ; script-src 'self' ; script-nonce ABCDE";
+
+header("Content-Security-Policy: $csp_headers");
+?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<body>See HTTP header "Content-Security-Policy" values.</body>
+</html>

--- a/webroot/moth/w3af/grep/csp/index.php
+++ b/webroot/moth/w3af/grep/csp/index.php
@@ -1,0 +1,11 @@
+<?php 
+header('X-Frame-Options: DENY');
+session_start();
+?>
+<h1>Content Security Policy (CSP) test pages</h1>
+<ul>
+    <li><a href="csp_without_error.php">Page without any error</a></li>
+    <li><a href="csp_with_error_1.php">Page with error relation part 1</a></li>
+    <li><a href="csp_with_error_2.php">Page with error relation part 2</a></li>
+    <li><a href="csp_with_error_3.php">Page with error relation part 3</a></li>
+</ul>

--- a/webroot/moth/w3af/grep/index.html
+++ b/webroot/moth/w3af/grep/index.html
@@ -52,6 +52,7 @@
 <LI><A HREF="strange_parameters/">strange_parameters/</A>
 <LI><A HREF="svn_users/">svn_users/</A>
 <LI><A HREF="wsdl_greper/">wsdl_greper/</A>
+<LI><A HREF="csp/">csp/</A>
 </UL>
 
 </div id="body">


### PR DESCRIPTION
Hello,

Pull request to add test scripts used by unit test cases implemented for the **Content Security Policy (CSP)** W3AF Grep plugin.

Index of the Grep section has been updated and an index has been also added into the sub folder dedicated to CSP scripts.

Pull request for CSP Grep plugin itself will follow this pull request :wink: 

Thanks in advance.
